### PR TITLE
use a relevant stack trace in makeCombinedError()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,10 @@ REPORTER = spec
 lint:
 	./node_modules/.bin/jshint ./test ./index.js
 
-test:
-	$(MAKE) lint
-	./node_modules/.bin/mocha --reporter $(REPORTER) --check-leaks -b
+test: lint
+	./node_modules/.bin/mocha --reporter $(REPORTER) --check-leaks
 
-test-cov:
-	$(MAKE) lint
+test-cov: lint
 	./node_modules/.bin/istanbul cover \
 	./node_modules/mocha/bin/_mocha -- -b --reporter $(REPORTER) --check-leaks
 	echo "See reports at ./coverage/lcov-report/index.html"

--- a/index.js
+++ b/index.js
@@ -288,13 +288,23 @@ Verity.prototype.test = function(cb) {
 };
 
 function makeCombinedError(errors) {
+  var keys = Object.keys(errors);
+
+  // if (keys.length === 1) {
+  //   var err = errors[keys[0]];
+  //   err.message = "Expectations failed:\n\u001b[0m" + err.message;
+  //   return err;
+  // }
+
   var msg = [];
-  for (var name in errors) {
+  keys.forEach(function(name) {
     msg.push(formatHeader(name));
     msg.push(errors[name].message);
-  }
+  });
 
-  return new Error("Expectations failed:\n\u001b[0m" + msg.join("\n"));
+  var combined = new Error("Expectations failed:\n\u001b[0m" + msg.join("\n"));
+  combined.stack = errors[keys[0]].stack;
+  return combined;
 }
 
 /*

--- a/test/index.js
+++ b/test/index.js
@@ -160,7 +160,9 @@ describe('verity', function(){
       expectBody('hello world').
       log(false).
       test(function(err, result){
-        expect(err.message).to.be('Expectations failed: Status, Body');
+        expect(err.message).to.contain("Expectations failed");
+        expect(err.message).to.contain("Status");
+        expect(err.message).to.contain("Body");
           //date header changes too much to test easily
         delete result.headers.date;
         var expected = {
@@ -258,7 +260,8 @@ describe('verity', function(){
       test(function(err, result){
         //date header changes too much to test easily
         delete result.headers.date;
-        expect(err.message).to.be("Expectations failed: Body");
+        expect(err.message).to.contain("Expectations failed:");
+        expect(err.message).to.contain("Body");
         var expected = {
           "errors": {
             "Body": {
@@ -297,7 +300,8 @@ describe('verity', function(){
       test(function(err, result){
         //date header changes too much to test easily
         delete result.headers.date;
-        expect(err.message).to.be("Expectations failed: Body");
+        expect(err.message).to.contain("Expectations failed:");
+        expect(err.message).to.contain("Body");
         var expected = {
           "errors": {
             "Body": {
@@ -330,12 +334,3 @@ describe('verity', function(){
       });
   });
 });
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
the changes to existing tests were because those were actually not passing on master already. My changes don't affect error messages, just the stack traces.