### PR TITLE
suppress expectation logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,13 +252,6 @@ Verity.prototype.test = function(cb) {
       var unnamedExpectationCount = 1;
       var errors = {};
 
-      var backendStack = res.headers[VERITY_STACK_HEADER] || res.headers[VERITY_STACK_HEADER.toLowerCase()];
-      if (backendStack) {
-        var e = new Error();
-        e.stack = new Buffer(backendStack, 'base64').toString('ascii');
-        errors.Backend = e;
-      }
-
       Object.keys(that._expectations).forEach(function(name){
         try {
           that._expectations[name].call(that, res);
@@ -282,6 +275,12 @@ Verity.prototype.test = function(cb) {
       };
 
       if (!_.isEmpty(errors)) {
+        var backendStack = res.headers[VERITY_STACK_HEADER] || res.headers[VERITY_STACK_HEADER.toLowerCase()];
+        if (backendStack) {
+          var e = new Error();
+          e.stack = new Buffer(backendStack, 'base64').toString('ascii');
+          errors.Backend = e;
+        }
         return cb(makeCombinedError(errors), result);
       } else {
         return cb(null, result);

--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ var deepmerge = require("deepmerge");
 var isSubset = util.isSubset;
 var assertObjectEquals = util.assertObjectEquals;
 
-
 var isString = function(str){
   return toString.call(str) == '[object String]';
 };
@@ -26,6 +25,8 @@ var isFunction = function(functionToCheck) {
  var getType = {};
  return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
 };
+
+var suppressExpectationLogging = false;
 
 // checks a response holistically, rather than in parts,
 // which results in better error output.
@@ -126,7 +127,6 @@ Verity.prototype.setAuthStrategy = function(strategy){
   this.authStrategy = strategy;
   return this;
 };
-
 
 Verity.prototype.setCookieFromString = function(str){
   var that = this;
@@ -284,6 +284,10 @@ Verity.prototype.test = function(cb) {
 };
 
 function makeCombinedError(errors) {
+  if (suppressExpectationLogging) {
+    return new Error("Expectations failed")
+  }
+
   var msg = [];
   var lastError;
   for (var name in errors) {
@@ -503,5 +507,9 @@ Verity.assertObjectEquals = assertObjectEquals;
 Verity.prototype.assertObjectEquals = assertObjectEquals;
 Verity.isSubset = isSubset;
 Verity.prototype.isSubset = isSubset;
+Verity.quiet = function (value) {
+  if (value === undefined) value = true;
+  suppressExpectationLogging = value;
+}
 
 module.exports = Verity;

--- a/test/index.js
+++ b/test/index.js
@@ -71,6 +71,13 @@ describe('verity', function(){
       res.send({gotCookies : req.cookies});
     });
 
+    app.get('/errorWithStack', function(req, res) {
+      var err = new Error("Kaboom!");
+      res.status(500);
+      res.header("X-Verity-Stack-Trace", new Buffer(err.stack).toString('base64'));
+      res.send({ error: err.message });
+    });
+
     app.get('/nested/path', function(req, res){
       res.send('nested path');
     });
@@ -341,6 +348,16 @@ describe('verity', function(){
           }
         };
         util.assertObjectEquals(flatten(result), flatten(expected));
+        done();
+      });
+  });
+  it("can accept stack traces from the backend", function (done) {
+    verity('http://localhost:3000/errorWithStack')
+      .jsonMode()
+      .expectStatus(200)
+      .test(function(err) {
+        expect(err.message).to.contain("Error: Kaboom!"); // backend error
+        expect(err.message).to.contain("Expected status 200 but got 500");
         done();
       });
   });


### PR DESCRIPTION
when working with lots of failing tests (large scale changes/refactors, for example), we often know or suspect the underlying cause of the failure and just want to know WHICH tests are failing without verbose expectation/diffing output. This PR introduces a top-level `Verity.quiet()` function to globally enable/disable verbose logging. The default behavior is the same as it was prior to this PR.